### PR TITLE
Fix crash on Fabric servers + Fix #mineable/pickaxe tag

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -23,7 +23,6 @@
     "thaumon:arcane_stone_pillar",
     "thaumon:runic_arcane_stone",
     "thaumon:tiled_arcane_stone",
-    "thaumon:runic_arcane_tiles",
     "thaumon:inlaid_arcane_stone",
     "thaumon:arcane_lantern",
     "thaumon:arcane_stone_window",
@@ -77,7 +76,6 @@
     "thaumon:arcane_stone_button",
     "thaumon:ancient_stone_button",
     "thaumon:arcane_stone_pressure_plate",
-    "thaumon:ancient_stone_pressure_plate",
-    "thaumon:witch_cauldron"
+    "thaumon:ancient_stone_pressure_plate"
   ]
 }

--- a/fabric/src/main/java/jdlenl/thaumon/client/fabric/ThaumonClientFabric.java
+++ b/fabric/src/main/java/jdlenl/thaumon/client/fabric/ThaumonClientFabric.java
@@ -1,5 +1,6 @@
 package jdlenl.thaumon.client.fabric;
 
+import jdlenl.thaumon.color.fabric.ColorProviderRegistries;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.minecraft.client.render.RenderLayer;
@@ -9,26 +10,32 @@ import static jdlenl.thaumon.block.ThaumonBlocks.*;
 public class ThaumonClientFabric implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        BlockRenderLayerMap.INSTANCE.putBlock(AMBERGLASS.get(), RenderLayer.getTranslucent());
-        BlockRenderLayerMap.INSTANCE.putBlock(AMBERGLASS_PANE.get(), RenderLayer.getTranslucent());
+        BlockRenderLayerMap.INSTANCE.putBlocks(RenderLayer.getTranslucent(),
+                AMBERGLASS.get(),
+                AMBERGLASS_PANE.get()
+        );
 
-        BlockRenderLayerMap.INSTANCE.putBlock(GREATWOOD_WINDOW.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(GREATWOOD_WINDOW_PANE.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(SILVERWOOD_WINDOW.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(SILVERWOOD_WINDOW_PANE.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(ARCANE_STONE_WINDOW.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(ARCANE_STONE_WINDOW_PANE.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(ELDRITCH_STONE_WINDOW.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(ELDRITCH_STONE_WINDOW_PANE.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(ANCIENT_STONE_WINDOW.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(ANCIENT_STONE_WINDOW_PANE.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(SILVERWOOD_DOOR.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(ANCIENT_STONE_DOOR.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(GREATWOOD_DOOR.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(GILDED_GREATWOOD_DOOR.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(SILVERWOOD_TRAPDOOR.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(GREATWOOD_TRAPDOOR.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(GILDED_GREATWOOD_TRAPDOOR.get(), RenderLayer.getCutout());
-        BlockRenderLayerMap.INSTANCE.putBlock(RESEARCH_NOTES.get(), RenderLayer.getCutout());
+        BlockRenderLayerMap.INSTANCE.putBlocks(RenderLayer.getCutout(),
+                GREATWOOD_WINDOW.get(),
+                GREATWOOD_WINDOW_PANE.get(),
+                SILVERWOOD_WINDOW.get(),
+                SILVERWOOD_WINDOW_PANE.get(),
+                ARCANE_STONE_WINDOW.get(),
+                ARCANE_STONE_WINDOW_PANE.get(),
+                ELDRITCH_STONE_WINDOW.get(),
+                ELDRITCH_STONE_WINDOW_PANE.get(),
+                ANCIENT_STONE_WINDOW.get(),
+                ANCIENT_STONE_WINDOW_PANE.get(),
+                SILVERWOOD_DOOR.get(),
+                ANCIENT_STONE_DOOR.get(),
+                GREATWOOD_DOOR.get(),
+                GILDED_GREATWOOD_DOOR.get(),
+                SILVERWOOD_TRAPDOOR.get(),
+                GREATWOOD_TRAPDOOR.get(),
+                GILDED_GREATWOOD_TRAPDOOR.get(),
+                RESEARCH_NOTES.get()
+        );
+
+        ColorProviderRegistries.init();
     }
 }

--- a/fabric/src/main/java/jdlenl/thaumon/fabric/ThaumonFabric.java
+++ b/fabric/src/main/java/jdlenl/thaumon/fabric/ThaumonFabric.java
@@ -1,7 +1,6 @@
 package jdlenl.thaumon.fabric;
 
 import jdlenl.thaumon.Thaumon;
-import jdlenl.thaumon.color.fabric.ColorProviderRegistries;
 import jdlenl.thaumon.itemgroup.fabric.ThaumonItemGroupFabric;
 import net.fabricmc.api.ModInitializer;
 
@@ -11,6 +10,5 @@ public class ThaumonFabric implements ModInitializer {
         Thaumon.init();
 
         ThaumonItemGroupFabric.init();
-        ColorProviderRegistries.init();
     }
 }


### PR DESCRIPTION
This PR moves the color provider registration to the client mod initializer of the Fabric module, preventing a crash on dedicated servers running on Fabric. It also removes missing blocks from the `#minecraft:mineable/pickaxe` tag, fixing pickaxes not being able to mine anything effectively in-game.

It also switches from `BlockRenderLayerMap#putBlock` to `BlockRenderLayerMap#putBlocks` in the Fabric client mod initializer, which looks nicer and might be slightly more performant.